### PR TITLE
Use AssemblyLoadContext to provide separation of dynamic assemblies

### DIFF
--- a/src/Pickler.Deserialize.cs
+++ b/src/Pickler.Deserialize.cs
@@ -1107,10 +1107,10 @@ namespace Ibasa.Pikala
 
         private Assembly? LookupWorkaroundAssembly(System.Runtime.Loader.AssemblyLoadContext alc)
         {
-            foreach(var assembly in alc.Assemblies)
+            foreach (var assembly in alc.Assemblies)
             {
                 var name = assembly.GetName();
-                if(name.Name == "DefineDynamicAssembly" && assembly.ManifestModule.ModuleVersionId == _ddaGuid)
+                if (name.Name == "DefineDynamicAssembly" && assembly.ManifestModule.ModuleVersionId == _ddaGuid)
                 {
                     return assembly;
                 }
@@ -1127,10 +1127,10 @@ namespace Ibasa.Pikala
 
             metadata.AddAssembly(
                 metadata.GetOrAddString("DefineDynamicAssembly"),
-                new Version(1, 0,0,0),
+                new Version(1, 0, 0, 0),
                 default(System.Reflection.Metadata.StringHandle),
                 default(System.Reflection.Metadata.BlobHandle),
-                flags: 0, 
+                flags: 0,
                 AssemblyHashAlgorithm.None);
 
             metadata.AddModule(
@@ -1169,9 +1169,10 @@ namespace Ibasa.Pikala
             var ddaSignature = new System.Reflection.Metadata.BlobBuilder();
             new System.Reflection.Metadata.Ecma335.BlobEncoder(ddaSignature)
                 .MethodSignature()
-                .Parameters(2, 
+                .Parameters(2,
                     returnType => returnType.Type().Type(assemblyBuilderRef, false),
-                    parameters => {
+                    parameters =>
+                    {
                         parameters.AddParameter().Type().Type(assemblyNameRef, false);
                         parameters.AddParameter().Type().Type(assemblyBuilderAccessRef, true);
                     });
@@ -1214,12 +1215,12 @@ namespace Ibasa.Pikala
 
             var peHeaderBuilder = new System.Reflection.PortableExecutable.PEHeaderBuilder();
             var peBuilder = new System.Reflection.PortableExecutable.ManagedPEBuilder(
-                peHeaderBuilder, 
+                peHeaderBuilder,
                 metadataRootBuilder,
-                ilBuilder, 
+                ilBuilder,
                 flags: System.Reflection.PortableExecutable.CorFlags.ILOnly,
                 deterministicIdProvider: content => contentId);
-            
+
             var builder = new System.Reflection.Metadata.BlobBuilder();
             peBuilder.Serialize(builder);
 
@@ -1279,7 +1280,7 @@ namespace Ibasa.Pikala
             }
 
             state.SetMemo(position, true, assembly);
-            
+
 
             ReadCustomAttributes(state, assembly.SetCustomAttribute, genericTypeParameters, genericMethodParameters);
             return assembly;

--- a/src/Pickler.cs
+++ b/src/Pickler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.Loader;
 
 namespace Ibasa.Pikala
 {
@@ -130,9 +131,12 @@ namespace Ibasa.Pikala
         private const uint _header = ((byte)'P' << 0 | (byte)'K' << 8 | (byte)'L' << 16 | (byte)'A' << 24);
         private const uint _version = 1U;
 
-        public Pickler(Func<Assembly, AssemblyPickleMode>? assemblyPickleMode = null)
+        public AssemblyLoadContext AssemblyLoadContext { get; private set; }
+
+        public Pickler(Func<Assembly, AssemblyPickleMode>? assemblyPickleMode = null, AssemblyLoadContext? assemblyLoadContext = null)
         {
             // By default assume nothing needs to be pickled by value
+            AssemblyLoadContext = (assemblyLoadContext ?? AssemblyLoadContext.CurrentContextualReflectionContext) ?? AssemblyLoadContext.Default;
             _assemblyPickleMode = assemblyPickleMode ?? (_ => AssemblyPickleMode.Default);
             _reducers = new Dictionary<Type, IReducer>();
 

--- a/tests/AssemblyLoadContextTests.cs
+++ b/tests/AssemblyLoadContextTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+
+namespace Ibasa.Pikala.Tests
+{
+    /// <summary>
+    /// Tests for AssemblyLoadContext useage
+    /// </summary>
+    public class AssemblyLoadContextTests
+    {
+        [Fact]
+        public void TestAssemblyLoadContext()
+        {
+            // Test that our dynamic assembly is loaded into the ALC passed to the pickler and not the default ALC.
+
+            var alc = new System.Runtime.Loader.AssemblyLoadContext("TestAssemblyLoadContext", true);
+
+            var pickler = new Pickler(null, alc);
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("DynamicAssembly"), AssemblyBuilderAccess.Run);
+            var assembly = RoundTrip.Do<Assembly>(pickler, assemblyBuilder);
+
+            Assert.Equal(assembly.FullName, assembly.FullName);
+
+            Assert.Contains(assembly, alc.Assemblies);
+            Assert.DoesNotContain(assembly, System.Runtime.Loader.AssemblyLoadContext.Default.Assemblies);
+        }
+
+
+        [Fact]
+        public void TestSharedALC()
+        {
+            // This test is to test that if we create one ALC and use it with two picklers that there are no issues with the workaround assembly we use.
+            // We're checking for racing and duplication problems here.
+
+            var alc = new System.Runtime.Loader.AssemblyLoadContext("TestSharedALC", true);
+
+            var pickler1 = new Pickler(null, alc);
+            var pickler2 = new Pickler(null, alc);
+
+            var assembly1 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC1"), AssemblyBuilderAccess.Run);
+            var assembly2 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC2"), AssemblyBuilderAccess.Run);
+
+            void TestAssert(Pickler pickler, AssemblyBuilder assemblyBuilder)
+            {
+                var assembly = RoundTrip.Do<Assembly>(pickler, assemblyBuilder);
+                Assert.Equal(assemblyBuilder.FullName, assembly.FullName);
+            }
+
+            var task1 = System.Threading.Tasks.Task.Run(() => TestAssert(pickler1, assembly1));
+            var task2 = System.Threading.Tasks.Task.Run((() => TestAssert(pickler2, assembly2)));
+
+            System.Threading.Tasks.Task.WaitAll(task1, task2);
+
+            var pickler3 = new Pickler(null, alc);
+            var assembly3 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC3"), AssemblyBuilderAccess.Run);
+            TestAssert(pickler3, assembly3);
+        }
+    }
+}

--- a/tests/DynamicTests.cs
+++ b/tests/DynamicTests.cs
@@ -73,5 +73,31 @@ namespace Ibasa.Pikala.Tests
 
             Assert.Contains("Ambiguous assembly name 'TestAmbiguousAssemblies, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null', found multiple matching assemblies.", exc.Message);
         }
+
+        [Fact]
+        public void TestSharedALC()
+        {
+            // This test is to test that if we create one ALC and use it with two picklers that there are no issues with the workaround assembly we use.
+            // We're checking for racing and duplication problems here.
+
+            var alc = new System.Runtime.Loader.AssemblyLoadContext("TestSharedALC", true);
+
+            var pickler1 = new Pickler(null, alc);
+            var pickler2 = new Pickler(null, alc);
+
+            var assembly1 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC1"), AssemblyBuilderAccess.Run);
+            var assembly2 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC2"), AssemblyBuilderAccess.Run);
+
+            void TestAssert(Pickler pickler, AssemblyBuilder assemblyBuilder)
+            {
+                var assembly = RoundTrip.Do<Assembly>(pickler, assemblyBuilder);
+                Assert.Equal(assemblyBuilder.FullName, assembly.FullName);
+            }
+
+            var task1 = System.Threading.Tasks.Task.Run(() => TestAssert(pickler1, assembly1));
+            var task2 = System.Threading.Tasks.Task.Run((() => TestAssert(pickler2, assembly2)));
+
+            System.Threading.Tasks.Task.WaitAll(task1, task2);
+        }
     }
 }

--- a/tests/DynamicTests.cs
+++ b/tests/DynamicTests.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using Xunit;
-using System.Linq;
 
 namespace Ibasa.Pikala.Tests
 {
@@ -72,32 +71,6 @@ namespace Ibasa.Pikala.Tests
             var exc = Assert.Throws<Exception>(() => RoundTrip.Do(pickler, type2));
 
             Assert.Contains("Ambiguous assembly name 'TestAmbiguousAssemblies, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null', found multiple matching assemblies.", exc.Message);
-        }
-
-        [Fact]
-        public void TestSharedALC()
-        {
-            // This test is to test that if we create one ALC and use it with two picklers that there are no issues with the workaround assembly we use.
-            // We're checking for racing and duplication problems here.
-
-            var alc = new System.Runtime.Loader.AssemblyLoadContext("TestSharedALC", true);
-
-            var pickler1 = new Pickler(null, alc);
-            var pickler2 = new Pickler(null, alc);
-
-            var assembly1 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC1"), AssemblyBuilderAccess.Run);
-            var assembly2 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestSharedALC2"), AssemblyBuilderAccess.Run);
-
-            void TestAssert(Pickler pickler, AssemblyBuilder assemblyBuilder)
-            {
-                var assembly = RoundTrip.Do<Assembly>(pickler, assemblyBuilder);
-                Assert.Equal(assemblyBuilder.FullName, assembly.FullName);
-            }
-
-            var task1 = System.Threading.Tasks.Task.Run(() => TestAssert(pickler1, assembly1));
-            var task2 = System.Threading.Tasks.Task.Run((() => TestAssert(pickler2, assembly2)));
-
-            System.Threading.Tasks.Task.WaitAll(task1, task2);
         }
     }
 }

--- a/tests/DynamicTests.cs
+++ b/tests/DynamicTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Xunit;
+using System.Linq;
+
+namespace Ibasa.Pikala.Tests
+{
+    /// <summary>
+    /// Test writing out refs to dynamic modules
+    /// </summary>
+    public class DynamicTests
+    {
+        [Fact]
+        public void TestDynamicAssemblyRef()
+        {
+            var pickler = new Pickler(_ => AssemblyPickleMode.PickleByReference);
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestDynamicAssemblyRef"), AssemblyBuilderAccess.Run);
+            RoundTrip.Assert(pickler, assembly);
+        }
+
+        [Fact]
+        public void TestDynamicModuleRef()
+        {
+            var pickler = new Pickler(_ => AssemblyPickleMode.PickleByReference);
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestDynamicModuleRef"), AssemblyBuilderAccess.Run);
+            var module = assembly.DefineDynamicModule("main");
+            RoundTrip.Assert(pickler, module);
+        }
+
+        [Fact]
+        public void TestDynamicTypeRef()
+        {
+            var pickler = new Pickler(_ => AssemblyPickleMode.PickleByReference);
+
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestDynamicTypeRef"), AssemblyBuilderAccess.Run);
+            var module = assembly.DefineDynamicModule("main");
+            var type = module.DefineType("test").CreateType();
+            RoundTrip.Assert(pickler, type);
+        }
+
+        [Fact]
+        public void TestDynamicTypeRef_UncreatedType()
+        {
+            var pickler = new Pickler(_ => AssemblyPickleMode.PickleByReference);
+
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestDynamicTypeRef_UncreatedType"), AssemblyBuilderAccess.Run);
+            var module = assembly.DefineDynamicModule("main");
+            var type = module.DefineType("test");
+            // We haven't created this type so we can't load it
+            var exc = Assert.Throws<Exception>(() =>
+            {
+                var _ = RoundTrip.Do<Type>(pickler, type);
+            });
+
+            Assert.Contains("Could not load type 'test' from module '<In Memory Module>'", exc.Message);
+        }
+
+        [Fact]
+        public void TestAmbiguousAssemblies()
+        {
+            var pickler = new Pickler(_ => AssemblyPickleMode.PickleByReference);
+
+            var assembly1 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestAmbiguousAssemblies"), AssemblyBuilderAccess.Run);
+            var module1 = assembly1.DefineDynamicModule("main");
+            var type1 = module1.DefineType("test").CreateType();
+
+            var assembly2 = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("TestAmbiguousAssemblies"), AssemblyBuilderAccess.Run);
+            var module2 = assembly2.DefineDynamicModule("main2");
+            var type2 = module2.DefineType("test2").CreateType();
+
+            var exc = Assert.Throws<Exception>(() => RoundTrip.Do(pickler, type2));
+
+            Assert.Contains("Ambiguous assembly name 'TestAmbiguousAssemblies, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null', found multiple matching assemblies.", exc.Message);
+        }
+    }
+}

--- a/tests/EmitTests.cs
+++ b/tests/EmitTests.cs
@@ -11,7 +11,13 @@ namespace Ibasa.Pikala.Tests
     {
         private Pickler CreatePickler()
         {
-            return new Pickler(assembly => assembly == System.Reflection.Assembly.GetExecutingAssembly() ? AssemblyPickleMode.PickleByValue : AssemblyPickleMode.Default);
+            var assemblyPickleMode = new Func<System.Reflection.Assembly, AssemblyPickleMode>(assembly =>
+                assembly == System.Reflection.Assembly.GetExecutingAssembly() ? AssemblyPickleMode.PickleByValue : AssemblyPickleMode.Default
+            );
+
+            var assemblyLoadContext = new System.Runtime.Loader.AssemblyLoadContext("EmitTest", true);
+
+            return new Pickler(assemblyPickleMode, assemblyLoadContext);
         }
 
         [Fact]
@@ -63,7 +69,13 @@ namespace Ibasa.Pikala.Tests
     {
         private Pickler CreatePickler()
         {
-            return new Pickler(assembly => assembly == System.Reflection.Assembly.GetExecutingAssembly() ? AssemblyPickleMode.PickleByValue : AssemblyPickleMode.Default);
+            var assemblyPickleMode = new Func<System.Reflection.Assembly, AssemblyPickleMode>(assembly =>
+                assembly == System.Reflection.Assembly.GetExecutingAssembly() ? AssemblyPickleMode.PickleByValue : AssemblyPickleMode.Default
+            );
+
+            var assemblyLoadContext = new System.Runtime.Loader.AssemblyLoadContext("EmitTest", true);
+
+            return new Pickler(assemblyPickleMode, assemblyLoadContext);
         }
 
         [Fact]

--- a/tests/LargeTests.cs
+++ b/tests/LargeTests.cs
@@ -14,7 +14,7 @@ namespace Ibasa.Pikala.Tests
                 Skip = "Skipping due to 32bit process";
             }
 
-            var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? "pull_request";
+            var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
             if (isLongRunning && eventName == "pull_request")
             {
                 Skip = "Skipping long running test for pull request";

--- a/tests/LargeTests.cs
+++ b/tests/LargeTests.cs
@@ -14,7 +14,7 @@ namespace Ibasa.Pikala.Tests
                 Skip = "Skipping due to 32bit process";
             }
 
-            var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME");
+            var eventName = Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME") ?? "pull_request";
             if (isLongRunning && eventName == "pull_request")
             {
                 Skip = "Skipping long running test for pull request";


### PR DESCRIPTION
This includes some black magic to work around loading dynamic assemblies into AssemblyLoadContext's pre net6.0 as well.