### PR TITLE
Add the concept of static final types

### DIFF
--- a/src/Pickler.Serialize.cs
+++ b/src/Pickler.Serialize.cs
@@ -1618,7 +1618,7 @@ namespace Ibasa.Pikala
                             if (info.StaticType == typeof(object) || info.StaticType == typeof(ValueType))
                             {
                                 needTypeToken = true;
-                            } 
+                            }
                             else if (info.StaticType == info.RuntimeType)
                             {
                                 needTypeToken = !IsStaticallyFinal(null, info.StaticType);

--- a/src/Pickler.Serialize.cs
+++ b/src/Pickler.Serialize.cs
@@ -1592,7 +1592,7 @@ namespace Ibasa.Pikala
                     var operation = operationEntry.Operation.Value;
                     // This is exactly the same method we use when deserialising, if we can infer the operation from the static type we
                     // don't write out operation tokens (and some other info like type refs)
-                    var inferedOperationToken = InferOperationFromStaticType(info.StaticType);
+                    var inferedOperationToken = InferOperationFromStaticType(null, info.StaticType);
                     if (inferedOperationToken.HasValue)
                     {
                         System.Diagnostics.Debug.Assert(inferedOperationToken.Value == operation, "Infered operation from static type didn't match intended operation");
@@ -1609,7 +1609,16 @@ namespace Ibasa.Pikala
                     switch (operation)
                     {
                         case PickleOperation.Enum:
-                            Serialize(state, info.RuntimeType, MakeInfo(info.RuntimeType, typeof(Type), true));
+                            System.Diagnostics.Debug.Assert(info.RuntimeType.IsEnum, "Trying to enum serialise a type that is not an enum");
+                            System.Diagnostics.Debug.Assert(
+                                info.StaticType == info.RuntimeType || info.StaticType == typeof(object),
+                                "Static type for an enum value must be the enum or object",
+                                "Was {0}", info.StaticType);
+
+                            if (!IsStaticallyFinal(null, info.StaticType) || !info.StaticType.IsEnum)
+                            {
+                                Serialize(state, info.RuntimeType, MakeInfo(info.RuntimeType, typeof(Type), true));
+                            }
                             // typeCode for an enum will be something like Int32
                             WriteEnumerationValue(state.Writer, operationEntry.TypeCode, obj);
                             return;

--- a/src/Pickler.cs
+++ b/src/Pickler.cs
@@ -336,7 +336,8 @@ namespace Ibasa.Pikala
         }
 
         /// <summary>
-        /// Return true if the type is either a value type, or a sealed reference type from mscorlib.
+        /// Return true if the type is either a value type, or a sealed reference type that we know won't change between serialisation and deserialisation time.
+        /// This includes types from mscorlib and types that we've encoded into the pickle stream.
         /// </summary>
         /// <remarks>
         /// This is used when deciding if we need type tokens or not based on static context, if the static type
@@ -349,9 +350,11 @@ namespace Ibasa.Pikala
         /// time we come to deserialise the user may of changed them to a reference type leading the deserialiser to think there
         /// should be a type token.
         /// </remarks>
-        private bool IsStaticallyFinal(Type staticType)
+        private bool IsStaticallyFinal(Func<Assembly, bool>? isConstructed, Type staticType)
         {
-            return staticType.Assembly == mscorlib && (staticType.IsValueType || staticType.IsSealed);
+            return 
+                (staticType.IsValueType || staticType.IsSealed) &&
+                (staticType.Assembly == mscorlib || (isConstructed == null ? _assemblyPickleMode(staticType.Assembly) == AssemblyPickleMode.PickleByValue : isConstructed(staticType.Assembly)));
         }
     }
 }

--- a/src/Pickler.cs
+++ b/src/Pickler.cs
@@ -356,7 +356,7 @@ namespace Ibasa.Pikala
         /// </remarks>
         private bool IsStaticallyFinal(Func<Assembly, bool>? isConstructed, Type staticType)
         {
-            return 
+            return
                 (staticType.IsValueType || staticType.IsSealed) &&
                 (staticType.Assembly == mscorlib || (isConstructed == null ? _assemblyPickleMode(staticType.Assembly) == AssemblyPickleMode.PickleByValue : isConstructed(staticType.Assembly)));
         }

--- a/src/Pickler.cs
+++ b/src/Pickler.cs
@@ -232,7 +232,7 @@ namespace Ibasa.Pikala
             RegisterReducer(new DictionaryReducer());
         }
 
-        private PickleOperation? InferOperationFromStaticType(Type staticType)
+        private PickleOperation? InferOperationFromStaticType(Func<Assembly, bool>? isConstructed, Type staticType)
         {
             PickleOperation? Infer(Type staticType)
             {
@@ -303,6 +303,10 @@ namespace Ibasa.Pikala
                     else if (IsTupleType(staticType) && staticType.IsValueType)
                     {
                         return PickleOperation.ValueTuple;
+                    }
+                    else if (IsStaticallyFinal(isConstructed, staticType) && staticType.IsEnum)
+                    {
+                        return PickleOperation.Enum;
                     }
                 }
 

--- a/src/Pickler.cs
+++ b/src/Pickler.cs
@@ -232,7 +232,6 @@ namespace Ibasa.Pikala
             RegisterReducer(new DictionaryReducer());
         }
 
-
         private PickleOperation? InferOperationFromStaticType(Type staticType)
         {
             PickleOperation? Infer(Type staticType)
@@ -334,6 +333,25 @@ namespace Ibasa.Pikala
         {
             return type.Assembly == mscorlib && type.Namespace == "System" && (
                 type.Name.StartsWith("ValueTuple", StringComparison.Ordinal) || type.Name.StartsWith("Tuple", StringComparison.Ordinal));
+        }
+
+        /// <summary>
+        /// Return true if the type is either a value type, or a sealed reference type from mscorlib.
+        /// </summary>
+        /// <remarks>
+        /// This is used when deciding if we need type tokens or not based on static context, if the static type
+        /// is a value type or a sealed type then we know that the runtime type must be equal to that (because there
+        /// are no subtypes). Contrast this with when the static type is a non-sealed reference type, the runtime type
+        /// that we serialise (and then later need to deserialse) could be any subtype of it.
+        ///
+        /// This only applies to types within mscorlib because we don't expect them to change, but they're common enough
+        /// that this gives a good saving of type tokens. Other types might be value type when we serialise them, but by the
+        /// time we come to deserialise the user may of changed them to a reference type leading the deserialiser to think there
+        /// should be a type token.
+        /// </remarks>
+        private bool IsStaticallyFinal(Type staticType)
+        {
+            return staticType.Assembly == mscorlib && (staticType.IsValueType || staticType.IsSealed);
         }
     }
 }

--- a/src/PicklerState.cs
+++ b/src/PicklerState.cs
@@ -94,6 +94,11 @@ namespace Ibasa.Pikala
             AppDomain.CurrentDomain.TypeResolve += CurrentDomain_TypeResolve;
         }
 
+        public bool IsConstructedAssembly(System.Reflection.Assembly assembly)
+        {
+            return _constructedTypes.ContainsKey(assembly);
+        }
+
         public void AddTypeDef(PickledTypeInfoDef type)
         {
             var assembly = type.TypeBuilder.Assembly;

--- a/tests/CompatibilityTests.cs
+++ b/tests/CompatibilityTests.cs
@@ -185,10 +185,10 @@ namespace Ibasa.Pikala.Tests
 
         static Type[] BasicTypes = new Type[]
             {
-                        typeof(bool), typeof(byte), typeof(short), typeof(int), typeof(long),
-                        typeof(char), typeof(sbyte), typeof(ushort), typeof(uint), typeof(ulong),
-                        typeof(string), typeof(ConsoleColor), typeof(TestTypes.EnumurationType),
-                        typeof(TestTypes.StructureType), typeof(TestTypes.ClassType),
+                typeof(bool), typeof(byte), typeof(short), typeof(int), typeof(long),
+                typeof(char), typeof(sbyte), typeof(ushort), typeof(uint), typeof(ulong),
+                typeof(string), typeof(ConsoleColor), typeof(TestTypes.EnumurationType),
+                typeof(TestTypes.StructureType), typeof(TestTypes.ClassType),
             };
 
         static Type GenerateType(ref FsCheck.Random.StdGen stdGen)


### PR DESCRIPTION
Static final types (god this needs a better name) are types that we know won't change between serialization and deserialization. Currently this is sealed and value types in mscorlib or that we've written out as typedefs. This allows us to skip some type tokens, for example with enums if we have a static type of `TypeCode` then we'll have the same static type at deserialization time and so will know without op codes or type tokens that this is an enum and it's the `TypeCode` enum.

There are some things to think about regarding `Nullable<T>` that have been thrown up by this work. When we cast a `Nullable<T>` to an object it unboxs it so our runtime won't ever be `Nullable<T>` at serialization time. If we've got a `Nullable<T>` we need the op token (because it might be Null) but we can still save the type token if the inner type is statically final.