### PR TITLE
Make assembly trailer explicit

### DIFF
--- a/src/PicklerState.cs
+++ b/src/PicklerState.cs
@@ -380,7 +380,6 @@ namespace Ibasa.Pikala
 
             if (depth == 0)
             {
-                var postTrailers = new List<Action>();
                 while (trailers.Count > 0)
                 {
                     var trailer = trailers.Pop();


### PR DESCRIPTION
This is the first part of a larger work to remove the `RunWithTrailers` code, but to also remove the need for memo callbacks.